### PR TITLE
Rephrase entry to include DNS address in config

### DIFF
--- a/support/setup
+++ b/support/setup
@@ -80,7 +80,7 @@ echo "# ---------------------------
 #								
 # ---------------------------
 
-# IP ADDRESS OF MQTT BROKER
+# DNS OR IP ADDRESS OF MQTT BROKER
 mqtt_address=0.0.0.0
 
 # MQTT BROKER USERNAME (OR BLANK FOR NONE)


### PR DESCRIPTION
Changed description of `mqtt_address` to "DNS OR IP ADDRESS" since a Mosquitto connection can be made against either.

This is most likely not new information for an advanced user.