### PR TITLE
Added option for custom configuration directory

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -529,7 +529,7 @@ determine_name () {
 	if [ -z "$expected_name" ]; then 
 
 		#CHECK CACHE
-		expected_name=$(grep "$address" < ".public_name_cache" | awk -F "\t" '{print $2}')
+		expected_name=$(grep "$address" < "$base_directory/.public_name_cache" | awk -F "\t" '{print $2}')
 
 		#IF CACHE DOES NOT EXIST, TRY TO SCAN
 		if [ -z "$expected_name" ]; then 

--- a/support/argv
+++ b/support/argv
@@ -103,6 +103,7 @@ usage:
 				a \$mqtt_topicpath/scan/ARRIVE (defined in MQTT preferences file)
 				d \$mqtt_topicpath/scan/DEPART (defined in MQTT preferences file)
 				r send ARRIVE or DEPART messages to trigger other devices to scan 
+        monitor -D[dir] use alternative directory for configuration files
 	"
 }
 
@@ -129,8 +130,10 @@ PREF_FORMAT_MQTT=false
 PREF_PUBLISH_ENVIRONMENT_MODE=false
 PREF_HEARTBEAT=false
 PREF_MQTT_REPORT_SCAN_MESSAGES=false
+PREF_SERVICE_CHECK=true
+PREF_CONFIG_DIR=''
 
-while getopts "h?vrfbut:EgRcCmesadx" opt; do
+while getopts "h?vrfbut:EgRcCmesadxD:" opt; do
 	case "$opt" in
 		h|\?)
 			show_help_text
@@ -188,6 +191,9 @@ while getopts "h?vrfbut:EgRcCmesadx" opt; do
 			;;
 		m)  PREF_HEARTBEAT=true 	&& echo "> send heartbeat signal"
 			;;
+                D)  PREF_CONFIG_DIR=$OPTARG && echo "> using custom config directory [$PREF_CONFIG_DIR]"
+                    [ ! -d "$PREF_CONFIG_DIR" ] && echo "> error: config directory [$PREF_CONFIG_DIR] doesn't exist" && exit 1
+                        ;;
 		*)	echo "> unknown argument: $opt"
 	esac
 done

--- a/support/setup
+++ b/support/setup
@@ -37,14 +37,15 @@ should_exit=false
 
 #BASE DIRECTORY REGARDLESS OF INSTALLATION; ELSE MANUALLY SET HERE
 base_directory=$(dirname "$(readlink -f "$0")")
+[ ! -z "$PREF_CONFIG_DIR" ] && echo "Using $PREF_CONFIG_DIR as config dir" && base_directory="$PREF_CONFIG_DIR"
 
 #SET THE NAME CACHE IF IT DOESN'T EXIST
 [ ! -f "$base_directory/.public_name_cache" ] && echo "" > "$base_directory/.public_name_cache"
 [ ! -f "address_blacklist" ] && echo "#LIST MAC ADDRESSES TO IGNORE, ONE PER LINE:
-" > "address_blacklist"
+" > "$base_directory/address_blacklist"
 
 #BLACKLISTED ADDRESSES
-ADDRESS_BLACKLIST="address_blacklist"
+ADDRESS_BLACKLIST="$base_directory/address_blacklist"
 
 #----------------------------------------------------------------------------------------
 # CHECK MQTT CONFIGURATION FILES


### PR DESCRIPTION
Makes it possible to specify config directory as a command line option `-D config_dir`
This is especially useful when script is running within container, but can be used with regular setup.