### PR TITLE
Prevent infinite echo loop

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -1203,7 +1203,7 @@ while true; do
 				#exit
 				exit 0	
 
-			elif [[ $mqtt_topic_branch =~ .*ECHO.* ]]; then 
+			elif [[ $mqtt_topic_branch =~ .*ECHO.* ]] && [[ -z "$data_of_instruction" ]]; then 
 				$PREF_VERBOSE_LOGGING && log "${GREEN}[CMD-INST]	${NC}[${GREEN}pass mqtt${NC}] echo  ${NC}"				
 				
 				mqtt_echo


### PR DESCRIPTION
Maybe i'm doing it wrong, but when i send a message like `monitor/scan/echo` (where i'd expect all nodes to reply) or `monitor/monitor1/echo` (where i'd expect just the single node to reply), what ends up happening is in both cases both of my nodes picks up the echo, and then sends out their reply at `monitor/monitor1/echo` (and `monitor/monitor2/echo`), which then triggers the echo's again...and again...and again...and again :)

This change prevents the infinite loop by only replying when the mqtt message does NOT contain a message payload instead of always replying to every message that contained `echo` in the topic. So while the infinite echo loop (when there are 2+ nodes) is gone, it still doesn't entirely fix it to my expectations though...

I can send a message to `monitor/scan/echo` and get a single reply from both `monitor1` and `monitor2`. If I send a message to `monitor/monitor1/echo`, then I get a single reply from `monitor2` (and in theory any other node except `monitor1`. The reason is of course because of the filter further up in the code that skips messages where the publisher identity is itself. I'm not sure that its really all the crucial to have the singular node echo...so I'm not too concerned about getting that working by hacking up the that filter.

Thoughts/concerns?