### PR TITLE
Handle MQTT DNS lookup issue

### DIFF
--- a/support/mqtt
+++ b/support/mqtt
@@ -165,6 +165,7 @@ mqtt_error_handler () {
 		#ERRORS 
 		[[ ${received^^} =~ .*REFUSED.* ]] && return_value=1 && print_message="mqtt broker refused connection - check username, password, and host address"
 		[[ ${received^^} =~ .*NETWORK.* ]] && return_value=0 && print_message="network is down. enqueuing command to try again after a delay"
+		[[ ${received^^} =~ .*"LOOKUP ERROR".* ]] && return_value=0 && print_message="issue connecting to mqtt server (lookup error). enqueuing command to try again after a delay"
 
 		if [ -n "$last_error_message" ] && [ "$last_error_message" == "$print_message" ]; then 
 			#HERE, WE HAVE A REPEATED ERROR


### PR DESCRIPTION
Recently (possibly after a round of updates on my RPi), monitor started to fail to report my device as "away" when I performed a departure scan. After looking into it, I found that some MQTT messages weren't getting to the broker. For example, the first departure scan message (confidence=90) would be received by the broker, but the subsequent messages (confidence=45, confidence=0) would not make it. It seemed similar to issue #173, which is closed.

After adding some debugging, I found the following error message coming from the MQTT process: `Unable to connect (Lookup error.).`. It appears that - intermittently - a DNS lookup fails, which causes the MQTT process to fail silently (it looks like success to the `monitor` process).

This PR adds a new line to the `mqtt_error_handler` function to recognize this issue and react appropriately (i.e. try again).

Note that this issue might point to a possible bug in the error handler function that causes it to silently "pass" unrecognized errors, instead of reporting them. Perhaps the return code could be checked as part of the error handler?