### PR TITLE
Dev python bluez

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sudo apt-get install -f libmosquitto-dev mosquitto mosquitto-clients libmosquitt
 ```
 </details>
 
-<details><summary><i>Monitor Setup</i></summary>
+<details><summary><i>Monitor and Bluetooth-Proximity Setup</i></summary>
 
 ## Setup `monitor and bluetooth-proximity`
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo reboot
 5. Install Bluetooth Firmware, if necessary:
 ```bash
 #install Bluetooth drivers for Pi Zero W
-sudo apt-get install pi-bluetooth
+sudo apt-get install pi-bluetooth bluetooth python-bluez
 
 ```
 
@@ -92,13 +92,13 @@ sudo wget http://repo.mosquitto.org/debian/mosquitto-buster.list
 #update caches and install 
 apt-cache search mosquitto
 sudo apt-get update
-sudo apt-get install -f libmosquitto-dev mosquitto mosquitto-clients libmosquitto1
+sudo apt-get install -f libmosquitto-dev mosquitto mosquitto-clients libmosquitto1 
 ```
 </details>
 
 <details><summary><i>Monitor Setup</i></summary>
 
-## Setup `monitor`
+## Setup `monitor and bluetooth-proximity`
 
 1. Clone `monitor` git:
 ```bash
@@ -106,8 +106,16 @@ sudo apt-get install -f libmosquitto-dev mosquitto mosquitto-clients libmosquitt
 cd ~
 sudo apt-get install git
 
-#clone this repo
+#install Python setuptools
+sudo apt-get install python-setuptools
+
+#clone monitor and bluetooth-proximity repo
 git clone git://github.com/andrewjfreyer/monitor
+git clone https://github.com/ewenchou/bluetooth-proximity.git
+
+#install bluetooth-proximity
+cd bluetooth-proximity
+sudo python setup.py install
 
 #enter `monitor` directory
 cd monitor/

--- a/monitor.sh
+++ b/monitor.sh
@@ -275,16 +275,13 @@ connectable_present_devices () {
 			#AVERAGE OVER THREE CYCLES; IF BLANK GIVE VALUE OF 100
 			known_device_rssi=$(counter=0; \
 				avg_total=0; \
-				hcitool cc "$known_addr"; \
 				avg_total=""; \
 				for i in 1 2 3; \
-				do scan_result=$(hcitool rssi "$known_addr" 2>&1); \
+				do scan_result=$(python rssi.py "$known_addr"); \
+				[[ "$scan_result" == "None" ]] && scan_result=99; \
 				scan_result=${scan_result//[^0-9]/}; \
-				scan_result=${scan_result:-99}; \
-				[[ "$scan_result" == "0" ]] && scan_result=99; \
 				counter=$((counter+1)); \
 				avg_total=$((avg_total + scan_result )); \
-				sleep 0.5; \
 				done; \
 				printf "%s" "$(( avg_total / counter ))")
 

--- a/rssi.py
+++ b/rssi.py
@@ -1,0 +1,31 @@
+from bt_proximity import BluetoothRSSI
+import time
+import sys
+
+BT_ADDR = ''  # You can put your Bluetooth address here
+NUM_LOOP = 1
+
+def print_usage():
+    print "Usage: python test_address.py <bluetooth-address> [number-of-requests]"
+
+
+def main():
+    if len(sys.argv) > 1:
+        addr = sys.argv[1]
+    elif BT_ADDR:
+        addr = BT_ADDR
+    else:
+        print_usage()
+        return
+    if len(sys.argv) == 3:
+        num = int(sys.argv[2])
+    else:
+        num = NUM_LOOP
+    btrssi = BluetoothRSSI(addr=addr)
+    for i in range(0, num):
+        print btrssi.get_rssi()
+        time.sleep(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
readme.MD: instructions to install bluetooth, python-bluez package and python-setuptools. clone ewenchou/bluetooth-proximity repo and install the script. 

A new file rssi.py added to get rssi of mobile devices

monitor.sh script adapted to python-bluez and the rssi.py script. 