### PR TITLE
Log full event when loglevel is verbose

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -870,6 +870,9 @@ while true; do
 	#READ FROM THE MAIN PIPE
 	while read -r event; do
 
+		# Log the event for further debugging
+		$PREF_VERBOSE_LOGGING && log "${GREEN}[EVENT]	${NC} $event${NC}"
+
 		#DIVIDE EVENT MESSAGE INTO TYPE AND DATA
 		cmd="${event:0:4}"
 		data="${event:4}"


### PR DESCRIPTION
# Motivation
I have the same error as described [here](https://community.home-assistant.io/t/monitor-reliable-multi-user-distributed-bluetooth-occupancy-presence-detection/68505/1160)

I also get other warnings which I am not able to debug:
```
/usr/local/bin/monitor: line 955: 15922361RSLAL: value too great for base (error token is "15922361RSLAL")
```

In order to debug the problem, it would help to get more detailed informations.

This PR will add verbose logging for the whole event. In case, the verbose logging is not the correct thing, I could also add a new configuration variable like `PREF_VERBOSE_LOGGING_EVENT`.