### PR TITLE
Remove source_type field from see service example

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,7 +407,6 @@ As an example:
       data:
         dev_id: andrew
         location_name: home
-        source_type: bluetooth
 
 - alias: Andrew Occupancy Off
   trigger:
@@ -419,7 +418,6 @@ As an example:
       data:
         dev_id: andrew
         location_name: not_home
-        source_type: bluetooth
 
 ```
 


### PR DESCRIPTION
The field is not implemented:

<https://github.com/home-assistant/core/blob/39336d3ea367e5c50e88fa09165257290a07b150/homeassistant/components/device_tracker/services.yaml>

<https://github.com/home-assistant/core/blob/39336d3ea367e5c50e88fa09165257290a07b150/homeassistant/components/device_tracker/config_entry.py#L45-L48>