### PR TITLE
force rssi calculation to use 10 as base

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -1774,7 +1774,7 @@ while true; do
 				rssi_latest=${rssi_latest:--200}
 
 				#IS RSSI THE SAME? 
-				rssi_change=$((rssi - rssi_latest))
+				rssi_change=$((10#$rssi - 10#$rssi_latest))
 				abs_rssi_change=${rssi_change#-}
 
 				#DETERMINE MOTION DIRECTION


### PR DESCRIPTION
According to https://stackoverflow.com/questions/24777597/value-too-great-for-base-error-token-is-08 this is one way of preventing the bash script to treat 08 values as numbers with the base of 8. Tested it with the [Bluetooth BLE Presence ](https://github.com/Limych/addon-presence-monitor)