### PR TITLE
Update protocol for cloning in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cd ~
 sudo apt-get install git
 
 #clone this repo
-git clone git://github.com/andrewjfreyer/monitor
+git clone https://github.com/andrewjfreyer/monitor
 
 #enter `monitor` directory
 cd monitor/


### PR DESCRIPTION
Using git:// for cloning gives an error message. I suggest to use https://

--
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.