### PR TITLE
Add Home Assistant discovery

### DIFF
--- a/monitor.sh
+++ b/monitor.sh
@@ -206,6 +206,9 @@ for addr in "${known_static_addresses[@]^^}"; do
 	#FOR DEBUGGING
 	printf "%s\n" "> ${GREEN}$addr${NC} confidence topic: $pub_topic (has $is_connected to $PREF_HCI_DEVICE)"
 	[ "$PREF_DEVICE_TRACKER_REPORT" == 'true' ] && printf "%s\n" "> ${GREEN}$addr${NC} device_tracker topic: $pub_topic/$PREF_DEVICE_TRACKER_TOPIC_BRANCH [$PREF_DEVICE_TRACKER_AWAY_STRING or $PREF_DEVICE_TRACKER_HOME_STRING]"
+
+	#PUBLISH HOMEASSISTANT DISCOVERY CONFIG
+	[ "$PREF_DEVICE_TRACKER_REPORT" == 'true' ] && mqtt_homeassistant_discovery $mqtt_topic_branch $pub_topic/$PREF_DEVICE_TRACKER_TOPIC_BRANCH
 done
 
 # ----------------------------------------------------------------------------------------

--- a/support/mqtt
+++ b/support/mqtt
@@ -82,7 +82,7 @@ mqtt_homeassistant_discovery() {
 	$mqtt_version_append \
 	$mqtt_ca_file_append \
 	-L "${mqtt_url}homeassistant/device_tracker/$mqtt_publisher_identity/$1/config" \
-	-m "{\"state_topic\": \"$2\", \"name\": \"$1\", \"payload_home\": \"$PREF_DEVICE_TRACKER_HOME_STRING\", \"payload_not_home\": \"$PREF_DEVICE_TRACKER_AWAY_STRING\", \"unique_id\": \"$1_${mqtt_publisher_identity}_monitor\"}" \
+	-m "{\"state_topic\": \"$2\", \"name\": \"$1\", \"payload_home\": \"$PREF_DEVICE_TRACKER_HOME_STRING\", \"payload_not_home\": \"$PREF_DEVICE_TRACKER_AWAY_STRING\", \"unique_id\": \"$1_${mqtt_publisher_identity}_monitor\", \"source_type\": \"bluetooth_le\"}" \
 	-r \
 	-q "2" 2>&1)
 }

--- a/support/mqtt
+++ b/support/mqtt
@@ -72,6 +72,21 @@ mqtt_echo(){
 	-q "2" 2>&1)
 }
 
+# ----------------------------------------------------------------------------------------
+# MQTT HOMEASSISTANT DISCOVERY
+# ----------------------------------------------------------------------------------------
+mqtt_homeassistant_discovery() {
+	#ADD DISCOVERY CONFIG
+	mqtt_error_handler $($mosquitto_pub_path \
+	-I "$mqtt_publisher_identity" \
+	$mqtt_version_append \
+	$mqtt_ca_file_append \
+	-L "${mqtt_url}homeassistant/device_tracker/$mqtt_publisher_identity/$1/config" \
+	-m "{\"state_topic\": \"$2\", \"name\": \"$1\", \"payload_home\": \"$PREF_DEVICE_TRACKER_HOME_STRING\", \"payload_not_home\": \"$PREF_DEVICE_TRACKER_AWAY_STRING\", \"unique_id\": \"$1_${mqtt_publisher_identity}_monitor\"}" \
+	-r \
+	-q "2" 2>&1)
+}
+
 
 # ----------------------------------------------------------------------------------------
 # CLEAR RETAINED 


### PR DESCRIPTION
I've been using Monitor for a few years now, and I was just looking into getting them to show up as device trackers in Home Assistant. I noticed there is an option `PREF_DEVICE_TRACKER_REPORT` that allows reporting as device trackers, but there doesn't seem to be any functionality to announce these to Home Assistant.

This PR publishes MQTT Discovery message (as described [here](https://www.home-assistant.io/integrations/device_tracker.mqtt/#using-the-discovery-protocol)) on startup for all known static addresses, allowing them to automatically show up in Home Assistant.